### PR TITLE
 проверка при загрузке предпросмотра, aria-labelledby в карточку, отображение карточки способа поддержки

### DIFF
--- a/a11y-handbook/src/components/Card/Card.tsx
+++ b/a11y-handbook/src/components/Card/Card.tsx
@@ -33,9 +33,9 @@ export function Card({ title, path, resources = [], viewAllText }: CardProps) {
   const hasMoreResources = resources.length > 3;
 
   return (
-    <CardContainer>
+    <CardContainer aria-labelledby={title}>
       <CardHeader>
-        <CardTitle>{title}</CardTitle>
+        <CardTitle id={title}>{title}</CardTitle>
         {hasMoreResources && (
           <ViewAllLink to={path} aria-label={`Все ${resources.length} ${viewAllText}`} onClick={scrollToTop}>
             Все ({resources.length})

--- a/a11y-handbook/src/components/LinkPreview/LinkPreview.tsx
+++ b/a11y-handbook/src/components/LinkPreview/LinkPreview.tsx
@@ -148,11 +148,12 @@ const ErrorContainer = styled.div`
 interface LinkPreviewProps {
   url: string;
   onLoad: (data: PreviewData) => void;
+  onPreviewLoading?: (value: boolean) => void;
   getPreview?: (url: string, section: string) => Promise<PreviewData>;
   section?: string;
 }
 
-export function LinkPreview({ url, onLoad, getPreview, section }: LinkPreviewProps) {
+export function LinkPreview({ url, onLoad, onPreviewLoading, getPreview, section }: LinkPreviewProps) {
   const [loading, setLoading] = useState(false);
   const [previewData, setPreviewData] = useState<PreviewData | null>(null);
   const [error, setError] = useState('');
@@ -160,10 +161,10 @@ export function LinkPreview({ url, onLoad, getPreview, section }: LinkPreviewPro
   const mountedRef = useRef(true);
 
   // Сохраняем зависимости в ref
-  const propsRef = useRef({ url, onLoad, getPreview, section, previewCache });
+  const propsRef = useRef({ url, onLoad, onPreviewLoading, getPreview, section, previewCache });
   useEffect(() => {
-    propsRef.current = { url, onLoad, getPreview, section, previewCache };
-  }, [url, onLoad, getPreview, section, previewCache]);
+    propsRef.current = { url, onLoad, onPreviewLoading, getPreview, section, previewCache };
+  }, [url, onLoad, onPreviewLoading, getPreview, section, previewCache]);
 
   const fetchPreview = useCallback(async () => {
     const { url, onLoad, getPreview, section, previewCache } = propsRef.current;
@@ -192,7 +193,7 @@ export function LinkPreview({ url, onLoad, getPreview, section }: LinkPreviewPro
           },
           body: JSON.stringify({ url })
         });
-
+        
         if (!response.ok) {
           throw new Error('Failed to fetch preview');
         }
@@ -206,9 +207,9 @@ export function LinkPreview({ url, onLoad, getPreview, section }: LinkPreviewPro
         onLoad(data);
       }
     } catch (err) {
-      // if (mountedRef.current) {
-      //   setError('Не удалось загрузить предпросмотр');
-      // }
+      if (mountedRef.current) {
+        setError('Не удалось загрузить предпросмотр');
+      }
     } finally {
       if (mountedRef.current) {
         setLoading(false);
@@ -231,6 +232,7 @@ export function LinkPreview({ url, onLoad, getPreview, section }: LinkPreviewPro
   }
 
   if (error) {
+    onPreviewLoading && onPreviewLoading(false);
     return <ErrorContainer role="alert">{error}</ErrorContainer>;
   }
 

--- a/a11y-handbook/src/components/SuggestForm/SuggestForm.tsx
+++ b/a11y-handbook/src/components/SuggestForm/SuggestForm.tsx
@@ -110,6 +110,9 @@ export function SuggestForm({ getPreview }: SuggestFormProps) {
     }
   };
 
+  // функция для изменения состояния isPreviewLoading в компоненте LinkPreview
+  const handleIsPreviewLoadingChange = (value: boolean) => setIsPreviewLoading(value);
+
   const handleDescriptionChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setDescription(e.target.value);
   };
@@ -118,10 +121,10 @@ export function SuggestForm({ getPreview }: SuggestFormProps) {
     e.preventDefault();
     setError('');
 
-    // if (isPreviewLoading) {
-    //   setError('Дождитесь загрузки предпросмотра');
-    //   return;
-    // }
+    if (isPreviewLoading) {
+      setError('Дождитесь загрузки предпросмотра');
+      return;
+    }
     if (!url) {
       setError('Пожалуйста, заполните все обязательные поля');
       return;
@@ -239,6 +242,7 @@ export function SuggestForm({ getPreview }: SuggestFormProps) {
             <LinkPreview 
               url={url} 
               onLoad={handlePreviewLoad}
+              onPreviewLoading={handleIsPreviewLoadingChange}
               getPreview={getPreview}
               section={''}
             />
@@ -256,7 +260,7 @@ export function SuggestForm({ getPreview }: SuggestFormProps) {
           </ErrorMessage>
         )}
 
-        <SubmitButton type="submit" disabled={isLoading}>
+        <SubmitButton type="submit" disabled={isLoading || isPreviewLoading}>
           {isLoading ? (
             <>
               Отправка

--- a/a11y-handbook/src/context/AuthContext.tsx
+++ b/a11y-handbook/src/context/AuthContext.tsx
@@ -59,13 +59,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setIsLoading(false);
     };
     getSession();
-    // Подписка на изменения сессии
-    const { data: listener } = supabase.auth.onAuthStateChange(() => {
-      getSession();
-    });
-    return () => {
-      listener?.subscription.unsubscribe();
-    };
+    // Подписка на изменения сессии  -  закомментирована, чтобы избежать перезагрузки страниц в Админке при смене вкладок в браузере
+    // const { data: listener } = supabase.auth.onAuthStateChange(() => {
+    //   getSession();
+    // });
+    // return () => {
+    //   listener?.subscription.unsubscribe();
+    // };
   }, []);
 
   return (

--- a/a11y-handbook/src/pages/Support/styles.ts
+++ b/a11y-handbook/src/pages/Support/styles.ts
@@ -38,6 +38,14 @@ export const PaymentMethods = styled.ul`
   gap: 1.2rem;
   margin-top: 1.5rem;
   padding-inline-start: 0;
+
+  @media (min-width: 577px) and (max-width: 768px) {
+    justify-content: center;
+  }
+
+  @media (max-width: 576px) {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
 `;
 
 export const StyledLink = styled(Link)`


### PR DESCRIPTION
1. Черипикнула коммит "исправлен баг перезагрузки в админке" (в ветке main этот коммит уже есть, т.к. я его смержила в main, когда уже была ветка test).
2. Коммит "исправлена проверка при загрузке предпросмотра". Вернула проверку на предпросмотр. Добавила функцию для изменения состояния isPreviewLoading в компоненте LinkPreview в случае ошибки запроса, чтобы была возможность отправить материал (активна кнопка "Отправить").
3. Коммит "связан заголовок карточки с ссылкой на "Все N"". Добавила aria-labelledby в карточку.
4. Коммит "улучшено отображение карточки способа поддержки на небольших экранах". 577px-768px - центрировано, до 576px - растянуто на 100%.