### PR TITLE
улучшение невизуальной доступности

### DIFF
--- a/a11y-handbook/src/components/ResourceItem/ResourceItem.tsx
+++ b/a11y-handbook/src/components/ResourceItem/ResourceItem.tsx
@@ -123,30 +123,32 @@ export function ResourceItem({ resource }: ResourceItemProps) {
           {resource.title}
           <NewBadge createdAt={resource.createdAt} approvedAt={resource.approvedAt} />
         </ResourceTitle>
-        {resource.description && (
-          <ResourceDescription>
-            {resource.description}
-          </ResourceDescription>
-        )}
-        {resource.descriptionFull && (
-          <ResourceDescription>
-            {resource.descriptionFull}
-          </ResourceDescription>
-        )}
-        <DomainInfo>
-          {favicon && showFavicon ? (
-            <ResourceIcon 
-              src={favicon}
-              alt=""
-              onError={() => setShowFavicon(false)}
-            />
-          ) : (
-            <FallbackIcon>
-              {getDomainInitial()}
-            </FallbackIcon>
+        <div aria-hidden>
+          {resource.description && (
+            <ResourceDescription>
+              {resource.description}
+            </ResourceDescription>
           )}
-          <span>{resource.domain}</span>
-        </DomainInfo>
+          {resource.descriptionFull && (
+            <ResourceDescription>
+              {resource.descriptionFull}
+            </ResourceDescription>
+          )}
+          <DomainInfo>
+            {favicon && showFavicon ? (
+              <ResourceIcon 
+                src={favicon}
+                alt=""
+                onError={() => setShowFavicon(false)}
+              />
+            ) : (
+              <FallbackIcon>
+                {getDomainInitial()}
+              </FallbackIcon>
+            )}
+            <span>{resource.domain}</span>
+          </DomainInfo>
+        </div>
       </ResourceContent>
     </ResourceCard>
   );

--- a/a11y-handbook/src/pages/Home/Home.tsx
+++ b/a11y-handbook/src/pages/Home/Home.tsx
@@ -159,7 +159,7 @@ export const Home: FC<HomeProps> = ({
                                 section.slug === 'articles' ? 'статьи' :
                                 section.slug === 'blogs' ? 'блоги' :
                                 section.slug === 'guides' ? 'руководства' :
-                                section.slug === 'telegram' ? 'каналы' :
+                                section.slug === 'telegram' ? 'телеграмм каналы' :
                                 section.slug === 'podcasts' ? 'подкасты' :
                                 section.slug === 'courses' ? 'курсы' :
                                 section.slug === 'video' ? 'видео' :


### PR DESCRIPTION
Изменила подпись ссылке на все ресурсы блока Telegram, чтобы при возврате фокуса на нее клавишами было понятно, что это именно телеграм-каналы (с "мм" в конце произносит с правильным ударением).
На странице всех ресурсов оставила для скринридера только заголовок статьи.